### PR TITLE
Change background of attachment

### DIFF
--- a/kmail-enhanced-dark/style.css
+++ b/kmail-enhanced-dark/style.css
@@ -74,7 +74,7 @@ div#headerbox div.theactionbigcell{
 
 div#attachmentInjectionPoint div{
     color: #FFFFFF;
-    background-color: #141414 !important;
+    background-color: #30303050 !important;
     padding: 3px;
 }
 div#attachmentInjectionPoint span{


### PR DESCRIPTION
This change makes the background of attachment render better on several
levels of gray background of a dark theme, using lighter gray and
transparency. Looks better (IMHO) on Arc Dark and still looks great on
Breeze Dark.

I thought it would make a nice and easy PR if you happen to agree with this change (no problem if you don't).

Thanks for providing this theme!